### PR TITLE
ビルド設定修正

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+Documentation:
+  CommentFormat: Doxygen

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -47,7 +47,7 @@
             "binaryDir": "${sourceDir}/build/tidy",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "CMAKE_INSTALL_PREFIX": "${sourceDir}/staging/tidy}",
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/staging/tidy",
                 "CMAKE_CXX_CLANG_TIDY": "clang-tidy"
             }
         }


### PR DESCRIPTION
## 概要
- ビルド設定の不備を修正

## 変更内容
- 記述を修正
- clangdを追加

## 影響範囲
- 全体

## メモ
- コンパイラが指定されていなかったので設定→CMakeUserPresets.jsonを利用させる