### PR TITLE
<type_traits>をラップしたコンセプトを追加

### DIFF
--- a/src/public/mayo/types/concepts.hpp
+++ b/src/public/mayo/types/concepts.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "mayo/types/concepts/type_traits.hpp"

--- a/src/public/mayo/types/concepts/type_traits.hpp
+++ b/src/public/mayo/types/concepts/type_traits.hpp
@@ -3,243 +3,309 @@
 #include <type_traits>
 
 namespace mayo::concepts {
+
+// void 型判定
 template <class T>
 concept is_void = (std::is_void_v<T>);
 
+// nullptr 型判定
 template <class T>
 concept is_nullptr = (std::is_null_pointer_v<T>);
 
+// 整数型判定
 template <class T>
 concept is_int = (std::is_integral_v<T>);
 
+// 浮動小数点型判定
 template <class T>
 concept is_float = (std::is_floating_point_v<T>);
 
+// 配列型判定
 template <class T>
 concept is_array = (std::is_array_v<T>);
 
+// ポインタ型判定
 template <class T>
 concept is_ptr = (std::is_pointer_v<T>);
 
+// 左辺値参照型判定
 template <class T>
 concept is_lvalue_ref = (std::is_lvalue_reference_v<T>);
 
+// 右辺値参照型判定
 template <class T>
 concept is_rvalue_ref = (std::is_rvalue_reference_v<T>);
 
+// メンバオブジェクトポインタ型判定
 template <class T>
 concept is_member_object_ptr = (std::is_member_object_pointer_v<T>);
 
+// メンバ関数ポインタ型判定
 template <class T>
 concept is_member_func_ptr = (std::is_member_function_pointer_v<T>);
 
+// 列挙型判定
 template <class T>
 concept is_enum = (std::is_enum_v<T>);
 
+// union 型判定
 template <class T>
 concept is_union = (std::is_union_v<T>);
 
+// class 型判定
 template <class T>
 concept is_class = (std::is_class_v<T>);
 
+// 関数型判定
 template <class T>
 concept is_function = (std::is_function_v<T>);
 
+// 参照型判定
 template <class T>
 concept is_ref = (std::is_reference_v<T>);
 
+// 算術型判定
 template <class T>
 concept is_arithmetic = (std::is_arithmetic_v<T>);
 
+// 基本型判定
 template <class T>
 concept is_fundamental = (std::is_fundamental_v<T>);
 
+// オブジェクト型判定
 template <class T>
 concept is_object = (std::is_object_v<T>);
 
+// スカラー型判定
 template <class T>
 concept is_scalar = (std::is_scalar_v<T>);
 
+// 複合型判定
 template <class T>
 concept is_compound = (std::is_compound_v<T>);
 
+// メンバポインタ型判定
 template <class T>
 concept is_member_ptr = (std::is_member_pointer_v<T>);
 
+// scoped enum 判定
 template <class T>
 concept is_scoped_enum = (std::is_scoped_enum_v<T>);
 
+// const 修飾判定
 template <class T>
 concept is_const = (std::is_const_v<T>);
 
+// volatile 修飾判定
 template <class T>
 concept is_volatile = (std::is_volatile_v<T>);
 
+// トリビアルコピー可能判定
 template <class T>
 concept is_trivially_copyable = (std::is_trivially_copyable_v<T>);
 
+// 標準レイアウト判定
 template <class T>
 concept is_standard_layout = (std::is_standard_layout_v<T>);
 
+// 空クラス判定
 template <class T>
 concept is_empty = (std::is_empty_v<T>);
 
+// 多態型判定
 template <class T>
 concept is_polymorphic = (std::is_polymorphic_v<T>);
 
+// 抽象型判定
 template <class T>
 concept is_abstract = (std::is_abstract_v<T>);
 
+// final 判定
 template <class T>
 concept is_final = (std::is_final_v<T>);
 
+// 集成体判定
 template <class T>
 concept is_aggregate = (std::is_aggregate_v<T>);
 
+// 暗黙ライフタイム型判定
 template <class T>
 concept is_implicit_lifetime = (std::is_implicit_lifetime_v<T>);
 
+// 符号付き判定
 template <class T>
 concept is_signed = (std::is_signed_v<T>);
 
+// 符号なし判定
 template <class T>
 concept is_unsigned = (std::is_unsigned_v<T>);
 
+// 有界配列判定
 template <class T>
 concept is_bounded_array = (std::is_bounded_array_v<T>);
 
+// 無界配列判定
 template <class T>
 concept is_unbounded_array = (std::is_unbounded_array_v<T>);
 
+// 構築可能判定
 template <class T, class... Args>
 concept is_constructible = (std::is_constructible_v<T, Args...>);
 
+// デフォルト構築可能判定
 template <class T>
 concept is_default_constructible = (std::is_default_constructible_v<T>);
 
+// コピー構築可能判定
 template <class T>
 concept is_copy_constructible = (std::is_copy_constructible_v<T>);
 
+// ムーブ構築可能判定
 template <class T>
 concept is_move_constructible = (std::is_move_constructible_v<T>);
 
-template <class T, class U>
-concept is_assignable = (std::is_assignable_v<T, U>);
+// 代入可能判定
+template <class Target, class Source>
+concept is_assignable = (std::is_assignable_v<Target, Source>);
 
+// コピー代入可能判定
 template <class T>
 concept is_copy_assignable = (std::is_copy_assignable_v<T>);
 
+// ムーブ代入可能判定
 template <class T>
 concept is_move_assignable = (std::is_move_assignable_v<T>);
 
+// 破棄可能判定
 template <class T>
 concept is_destructible = (std::is_destructible_v<T>);
 
+// トリビアル構築可能判定
 template <class T, class... Args>
 concept is_trivially_constructible = (std::is_trivially_constructible_v<T, Args...>);
 
+// トリビアルデフォルト構築可能判定
 template <class T>
 concept is_trivially_default_constructible = (std::is_trivially_default_constructible_v<T>);
 
+// トリビアルコピー構築可能判定
 template <class T>
 concept is_trivially_copy_constructible = (std::is_trivially_copy_constructible_v<T>);
 
+// トリビアルムーブ構築可能判定
 template <class T>
 concept is_trivially_move_constructible = (std::is_trivially_move_constructible_v<T>);
 
-template <class T, class U>
-concept is_trivially_assignable = (std::is_trivially_assignable_v<T, U>);
+// トリビアル代入可能判定
+template <class Target, class Source>
+concept is_trivially_assignable = (std::is_trivially_assignable_v<Target, Source>);
 
+// トリビアルコピー代入可能判定
 template <class T>
 concept is_trivially_copy_assignable = (std::is_trivially_copy_assignable_v<T>);
 
+// トリビアルムーブ代入可能判定
 template <class T>
 concept is_trivially_move_assignable = (std::is_trivially_move_assignable_v<T>);
 
+// トリビアル破棄可能判定
 template <class T>
 concept is_trivially_destructible = (std::is_trivially_destructible_v<T>);
 
+// noexcept 構築可能判定
 template <class T, class... Args>
 concept is_nothrow_constructible = (std::is_nothrow_constructible_v<T, Args...>);
 
+// noexcept デフォルト構築可能判定
 template <class T>
 concept is_nothrow_default_constructible = (std::is_nothrow_default_constructible_v<T>);
 
+// noexcept コピー構築可能判定
 template <class T>
 concept is_nothrow_copy_constructible = (std::is_nothrow_copy_constructible_v<T>);
 
+// noexcept ムーブ構築可能判定
 template <class T>
 concept is_nothrow_move_constructible = (std::is_nothrow_move_constructible_v<T>);
 
-template <class T, class U>
-concept is_nothrow_assignable = (std::is_nothrow_assignable_v<T, U>);
+// noexcept 代入可能判定
+template <class Target, class Source>
+concept is_nothrow_assignable = (std::is_nothrow_assignable_v<Target, Source>);
 
+// noexcept コピー代入可能判定
 template <class T>
 concept is_nothrow_copy_assignable = (std::is_nothrow_copy_assignable_v<T>);
 
+// noexcept ムーブ代入可能判定
 template <class T>
 concept is_nothrow_move_assignable = (std::is_nothrow_move_assignable_v<T>);
 
+// noexcept 破棄可能判定
 template <class T>
 concept is_nothrow_destructible = (std::is_nothrow_destructible_v<T>);
 
+// 仮想デストラクタ有無判定
 template <class T>
 concept has_virtual_destructor = (std::has_virtual_destructor_v<T>);
 
+// swap 可能判定（2型）
 template <class T, class U>
 concept is_swappable_with = (std::is_swappable_with_v<T, U>);
 
+// swap 可能判定
 template <class T>
 concept is_swappable = (std::is_swappable_v<T>);
 
+// noexcept swap 可能判定（2型）
 template <class T, class U>
 concept is_nothrow_swappable_with = (std::is_nothrow_swappable_with_v<T, U>);
 
+// noexcept swap 可能判定
 template <class T>
 concept is_nothrow_swappable = (std::is_nothrow_swappable_v<T>);
 
+// ユニーク表現判定
 template <class T>
 concept has_unique_object_representations = (std::has_unique_object_representations_v<T>);
 
+// 同型判定
 template <class T, class U>
 concept is_same = (std::is_same_v<T, U>);
 
+// 基底関係判定
 template <class Base, class Derived>
 concept is_base_of = (std::is_base_of_v<Base, Derived>);
 
-template <class Base, class Derived>
-concept is_virtual_base_of = (std::is_virtual_base_of_v<Base, Derived>);
-
+// 変換可能判定
 template <class From, class To>
 concept is_convertible = (std::is_convertible_v<From, To>);
 
+// noexcept 変換可能判定
 template <class From, class To>
 concept is_nothrow_convertible = (std::is_nothrow_convertible_v<From, To>);
 
-template <class T, class U>
-concept is_layout_compatible = (__is_layout_compatible(T, U));
+// 一時オブジェクトからの参照構築可否
+template <class Ref, class Source>
+concept ref_constructs_from_tmp = (std::reference_constructs_from_temporary_v<Ref, Source>);
 
-template <class Base, class Derived>
-concept is_ptr_interconvertible_base_of = (__is_pointer_interconvertible_base_of(Base, Derived));
+// 一時オブジェクトからの参照変換可否
+template <class Ref, class Source>
+concept ref_converts_from_tmp = (std::reference_converts_from_temporary_v<Ref, Source>);
 
-template <class Ref, class T>
-concept ref_constructs_from_tmp = (std::reference_constructs_from_temporary_v<Ref, T>);
+// 呼び出し可能判定
+template <class Func, class... Args>
+concept is_invocable = (std::is_invocable_v<Func, Args...>);
 
-template <class Ref, class T>
-concept ref_converts_from_tmp = (std::reference_converts_from_temporary_v<Ref, T>);
+// 呼び出し結果の変換可能判定
+template <class Result, class Func, class... Args>
+concept is_invocable_result_convertible = (std::is_invocable_r_v<Result, Func, Args...>);
 
-template <class Fn, class... Args>
-concept is_invocable = (std::is_invocable_v<Fn, Args...>);
+// noexcept 呼び出し可能判定
+template <class Func, class... Args>
+concept is_nothrow_invocable = (std::is_nothrow_invocable_v<Func, Args...>);
 
-template <class R, class Fn, class... Args>
-concept is_invocable_result_convertible = (std::is_invocable_r_v<R, Fn, Args...>);
-
-template <class Fn, class... Args>
-concept is_nothrow_invocable = (std::is_nothrow_invocable_v<Fn, Args...>);
-
-template <class R, class Fn, class... Args>
-concept is_nothrow_invocable_result_convertible = (std::is_nothrow_invocable_r_v<R, Fn, Args...>);
-
-template <class = void>
-concept is_constant_evaluated = (std::is_constant_evaluated());
+// noexcept 呼び出し結果の変換可能判定
+template <class Result, class Func, class... Args>
+concept is_nothrow_invocable_result_convertible =
+    (std::is_nothrow_invocable_r_v<Result, Func, Args...>);
 } // namespace mayo::concepts

--- a/src/public/mayo/types/concepts/type_traits.hpp
+++ b/src/public/mayo/types/concepts/type_traits.hpp
@@ -1,0 +1,245 @@
+#pragma once
+
+#include <type_traits>
+
+namespace mayo::concepts {
+template <class T>
+concept is_void = (std::is_void_v<T>);
+
+template <class T>
+concept is_nullptr = (std::is_null_pointer_v<T>);
+
+template <class T>
+concept is_int = (std::is_integral_v<T>);
+
+template <class T>
+concept is_float = (std::is_floating_point_v<T>);
+
+template <class T>
+concept is_array = (std::is_array_v<T>);
+
+template <class T>
+concept is_ptr = (std::is_pointer_v<T>);
+
+template <class T>
+concept is_lvalue_ref = (std::is_lvalue_reference_v<T>);
+
+template <class T>
+concept is_rvalue_ref = (std::is_rvalue_reference_v<T>);
+
+template <class T>
+concept is_member_object_ptr = (std::is_member_object_pointer_v<T>);
+
+template <class T>
+concept is_member_func_ptr = (std::is_member_function_pointer_v<T>);
+
+template <class T>
+concept is_enum = (std::is_enum_v<T>);
+
+template <class T>
+concept is_union = (std::is_union_v<T>);
+
+template <class T>
+concept is_class = (std::is_class_v<T>);
+
+template <class T>
+concept is_function = (std::is_function_v<T>);
+
+template <class T>
+concept is_ref = (std::is_reference_v<T>);
+
+template <class T>
+concept is_arithmetic = (std::is_arithmetic_v<T>);
+
+template <class T>
+concept is_fundamental = (std::is_fundamental_v<T>);
+
+template <class T>
+concept is_object = (std::is_object_v<T>);
+
+template <class T>
+concept is_scalar = (std::is_scalar_v<T>);
+
+template <class T>
+concept is_compound = (std::is_compound_v<T>);
+
+template <class T>
+concept is_member_ptr = (std::is_member_pointer_v<T>);
+
+template <class T>
+concept is_scoped_enum = (std::is_scoped_enum_v<T>);
+
+template <class T>
+concept is_const = (std::is_const_v<T>);
+
+template <class T>
+concept is_volatile = (std::is_volatile_v<T>);
+
+template <class T>
+concept is_trivially_copyable = (std::is_trivially_copyable_v<T>);
+
+template <class T>
+concept is_standard_layout = (std::is_standard_layout_v<T>);
+
+template <class T>
+concept is_empty = (std::is_empty_v<T>);
+
+template <class T>
+concept is_polymorphic = (std::is_polymorphic_v<T>);
+
+template <class T>
+concept is_abstract = (std::is_abstract_v<T>);
+
+template <class T>
+concept is_final = (std::is_final_v<T>);
+
+template <class T>
+concept is_aggregate = (std::is_aggregate_v<T>);
+
+template <class T>
+concept is_implicit_lifetime = (std::is_implicit_lifetime_v<T>);
+
+template <class T>
+concept is_signed = (std::is_signed_v<T>);
+
+template <class T>
+concept is_unsigned = (std::is_unsigned_v<T>);
+
+template <class T>
+concept is_bounded_array = (std::is_bounded_array_v<T>);
+
+template <class T>
+concept is_unbounded_array = (std::is_unbounded_array_v<T>);
+
+template <class T, class... Args>
+concept is_constructible = (std::is_constructible_v<T, Args...>);
+
+template <class T>
+concept is_default_constructible = (std::is_default_constructible_v<T>);
+
+template <class T>
+concept is_copy_constructible = (std::is_copy_constructible_v<T>);
+
+template <class T>
+concept is_move_constructible = (std::is_move_constructible_v<T>);
+
+template <class T, class U>
+concept is_assignable = (std::is_assignable_v<T, U>);
+
+template <class T>
+concept is_copy_assignable = (std::is_copy_assignable_v<T>);
+
+template <class T>
+concept is_move_assignable = (std::is_move_assignable_v<T>);
+
+template <class T>
+concept is_destructible = (std::is_destructible_v<T>);
+
+template <class T, class... Args>
+concept is_trivially_constructible = (std::is_trivially_constructible_v<T, Args...>);
+
+template <class T>
+concept is_trivially_default_constructible = (std::is_trivially_default_constructible_v<T>);
+
+template <class T>
+concept is_trivially_copy_constructible = (std::is_trivially_copy_constructible_v<T>);
+
+template <class T>
+concept is_trivially_move_constructible = (std::is_trivially_move_constructible_v<T>);
+
+template <class T, class U>
+concept is_trivially_assignable = (std::is_trivially_assignable_v<T, U>);
+
+template <class T>
+concept is_trivially_copy_assignable = (std::is_trivially_copy_assignable_v<T>);
+
+template <class T>
+concept is_trivially_move_assignable = (std::is_trivially_move_assignable_v<T>);
+
+template <class T>
+concept is_trivially_destructible = (std::is_trivially_destructible_v<T>);
+
+template <class T, class... Args>
+concept is_nothrow_constructible = (std::is_nothrow_constructible_v<T, Args...>);
+
+template <class T>
+concept is_nothrow_default_constructible = (std::is_nothrow_default_constructible_v<T>);
+
+template <class T>
+concept is_nothrow_copy_constructible = (std::is_nothrow_copy_constructible_v<T>);
+
+template <class T>
+concept is_nothrow_move_constructible = (std::is_nothrow_move_constructible_v<T>);
+
+template <class T, class U>
+concept is_nothrow_assignable = (std::is_nothrow_assignable_v<T, U>);
+
+template <class T>
+concept is_nothrow_copy_assignable = (std::is_nothrow_copy_assignable_v<T>);
+
+template <class T>
+concept is_nothrow_move_assignable = (std::is_nothrow_move_assignable_v<T>);
+
+template <class T>
+concept is_nothrow_destructible = (std::is_nothrow_destructible_v<T>);
+
+template <class T>
+concept has_virtual_destructor = (std::has_virtual_destructor_v<T>);
+
+template <class T, class U>
+concept is_swappable_with = (std::is_swappable_with_v<T, U>);
+
+template <class T>
+concept is_swappable = (std::is_swappable_v<T>);
+
+template <class T, class U>
+concept is_nothrow_swappable_with = (std::is_nothrow_swappable_with_v<T, U>);
+
+template <class T>
+concept is_nothrow_swappable = (std::is_nothrow_swappable_v<T>);
+
+template <class T>
+concept has_unique_object_representations = (std::has_unique_object_representations_v<T>);
+
+template <class T, class U>
+concept is_same = (std::is_same_v<T, U>);
+
+template <class Base, class Derived>
+concept is_base_of = (std::is_base_of_v<Base, Derived>);
+
+template <class Base, class Derived>
+concept is_virtual_base_of = (std::is_virtual_base_of_v<Base, Derived>);
+
+template <class From, class To>
+concept is_convertible = (std::is_convertible_v<From, To>);
+
+template <class From, class To>
+concept is_nothrow_convertible = (std::is_nothrow_convertible_v<From, To>);
+
+template <class T, class U>
+concept is_layout_compatible = (__is_layout_compatible(T, U));
+
+template <class Base, class Derived>
+concept is_ptr_interconvertible_base_of = (__is_pointer_interconvertible_base_of(Base, Derived));
+
+template <class Ref, class T>
+concept ref_constructs_from_tmp = (std::reference_constructs_from_temporary_v<Ref, T>);
+
+template <class Ref, class T>
+concept ref_converts_from_tmp = (std::reference_converts_from_temporary_v<Ref, T>);
+
+template <class Fn, class... Args>
+concept is_invocable = (std::is_invocable_v<Fn, Args...>);
+
+template <class R, class Fn, class... Args>
+concept is_invocable_result_convertible = (std::is_invocable_r_v<R, Fn, Args...>);
+
+template <class Fn, class... Args>
+concept is_nothrow_invocable = (std::is_nothrow_invocable_v<Fn, Args...>);
+
+template <class R, class Fn, class... Args>
+concept is_nothrow_invocable_result_convertible = (std::is_nothrow_invocable_r_v<R, Fn, Args...>);
+
+template <class = void>
+concept is_constant_evaluated = (std::is_constant_evaluated());
+} // namespace mayo::concepts

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,5 +5,7 @@ function(add_unit_test source_file)
   add_executable(${target} "${source_file}")
   target_compile_options(${target} PRIVATE -UNDEBUG)
   target_link_libraries(${target} PRIVATE ${PROJECT_NAME})
-  add_test(NAME "unit_${stem}" COMMAND ${target})
+add_test(NAME "unit_${stem}" COMMAND ${target})
 endfunction()
+
+add_unit_test(types/concepts.cpp)

--- a/tests/types/concepts.cpp
+++ b/tests/types/concepts.cpp
@@ -1,0 +1,453 @@
+#include "mayo/types/concepts.hpp"
+
+#include <cassert>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace {
+struct Empty {};
+struct NonEmpty {
+    int value;
+};
+
+struct MemberHolder {
+    int value;
+    int method() const { return value; }
+};
+
+enum PlainEnum : std::uint8_t { PLAIN_A };
+enum class ScopedEnum : std::uint8_t { A };
+
+union SomeUnion {
+    int a;
+    float b;
+};
+
+struct Aggregate {
+    int value;
+};
+struct NonAggregate {
+    NonAggregate() : value(0) {}
+    int value;
+};
+
+struct IAbstract {
+    virtual void f() = 0;
+};
+
+struct Poly {
+    virtual ~Poly() = default;
+};
+
+struct Final final {};
+
+struct ImplicitLifetime {
+    int value;
+};
+struct NonImplicitLifetime {
+    ~NonImplicitLifetime() {}
+};
+
+struct NoDefault {
+    NoDefault() = delete;
+};
+
+struct Copyable {
+    Copyable() = default;
+    Copyable(const Copyable&) = default;
+    Copyable& operator=(const Copyable&) = default;
+};
+
+struct MoveOnly {
+    MoveOnly() = default;
+    MoveOnly(const MoveOnly&) = delete;
+    MoveOnly(MoveOnly&&) = default;
+    MoveOnly& operator=(MoveOnly&&) = default;
+};
+
+struct NonMovable {
+    NonMovable() = default;
+    NonMovable(NonMovable&&) = delete;
+};
+
+struct NoAssign {
+    NoAssign& operator=(const NoAssign&) = delete;
+};
+
+struct NoMoveAssign {
+    NoMoveAssign& operator=(NoMoveAssign&&) = delete;
+};
+
+struct NoDtor {
+    ~NoDtor() = delete;
+};
+
+struct NonTrivial {
+    NonTrivial() {}
+};
+
+struct NonTrivialCopy {
+    NonTrivialCopy(const NonTrivialCopy&) {}
+};
+
+struct NonTrivialMove {
+    NonTrivialMove(NonTrivialMove&&) noexcept {}
+};
+
+struct NonTrivialCopyAssign {
+    NonTrivialCopyAssign& operator=(const NonTrivialCopyAssign&) { return *this; }
+};
+
+struct NonTrivialMoveAssign {
+    NonTrivialMoveAssign& operator=(NonTrivialMoveAssign&&) noexcept { return *this; }
+};
+
+struct NonTrivialDtor {
+    ~NonTrivialDtor() {}
+};
+
+struct ThrowDefault {
+    ThrowDefault() noexcept(false) {}
+};
+
+struct ThrowCopy {
+    ThrowCopy() = default;
+    ThrowCopy(const ThrowCopy&) noexcept(false) {}
+};
+
+struct ThrowMove {
+    ThrowMove() = default;
+    ThrowMove(ThrowMove&&) noexcept(false) {}
+    ThrowMove& operator=(ThrowMove&&) noexcept(false) { return *this; }
+};
+
+struct NoThrowMove {
+    NoThrowMove() = default;
+    NoThrowMove(NoThrowMove&&) noexcept = default;
+    NoThrowMove& operator=(NoThrowMove&&) noexcept = default;
+};
+
+struct ThrowCopyAssign {
+    ThrowCopyAssign& operator=(const ThrowCopyAssign&) noexcept(false) { return *this; }
+};
+
+struct ThrowDtor {
+    ~ThrowDtor() noexcept(false) {}
+};
+
+struct HasVirtualDtor {
+    virtual ~HasVirtualDtor() = default;
+};
+
+struct NoVirtualDtor {};
+
+struct NoSwap {
+    NoSwap() = default;
+    NoSwap(NoSwap&&) = delete;
+    NoSwap& operator=(NoSwap&&) = delete;
+};
+
+struct NoThrowSwap {
+    int value;
+};
+
+inline void swap(NoThrowSwap& a, NoThrowSwap& b) noexcept {
+    std::swap(a.value, b.value);
+}
+
+struct ThrowSwap {
+    int value;
+};
+
+inline void swap(ThrowSwap& a, ThrowSwap& b) noexcept(false) {
+    std::swap(a.value, b.value);
+}
+
+struct ExplicitFromInt {
+    explicit ExplicitFromInt(int) {}
+};
+
+struct ImplicitFromInt {
+    ImplicitFromInt(int) {}
+};
+
+struct ThrowConvert {
+    operator int() noexcept(false) { return 0; }
+};
+
+struct LayoutA {
+    int x;
+};
+struct LayoutB {
+    double x;
+};
+
+struct PBase {
+    int x;
+};
+struct PDerived : PBase {
+    int y;
+};
+
+struct VirtualBase {};
+struct VirtualDerived : virtual VirtualBase {};
+struct NonVirtualDerived : VirtualBase {};
+
+int free_func(int) {
+    return 0;
+}
+
+struct Functor {
+    int operator()(int) noexcept { return 0; }
+};
+
+struct ThrowFunctor {
+    int operator()(int) noexcept(false) { return 0; }
+};
+
+struct MemberPair {
+    int a;
+    int b;
+};
+
+struct Padded {
+    char c;
+    int i;
+};
+} // namespace
+
+int main() {
+    using namespace mayo::concepts;
+
+    static_assert(is_void<void>);
+    static_assert(!is_void<int>);
+
+    static_assert(is_nullptr<std::nullptr_t>);
+    static_assert(!is_nullptr<void*>);
+
+    static_assert(is_int<int>);
+    static_assert(!is_int<float>);
+
+    static_assert(is_float<double>);
+    static_assert(!is_float<int>);
+
+    static_assert(is_array<int[2]>);
+    static_assert(!is_array<int>);
+
+    static_assert(is_ptr<int*>);
+    static_assert(!is_ptr<int>);
+
+    static_assert(is_lvalue_ref<int&>);
+    static_assert(!is_lvalue_ref<int&&>);
+
+    static_assert(is_rvalue_ref<int&&>);
+    static_assert(!is_rvalue_ref<int&>);
+
+    static_assert(is_member_object_ptr<int MemberHolder::*>);
+    static_assert(!is_member_object_ptr<int*>);
+
+    static_assert(is_member_func_ptr<int (MemberHolder::*)() const>);
+    static_assert(!is_member_func_ptr<int*>);
+
+    static_assert(is_enum<PlainEnum>);
+    static_assert(!is_enum<int>);
+
+    static_assert(is_union<SomeUnion>);
+    static_assert(!is_union<int>);
+
+    static_assert(is_class<Empty>);
+    static_assert(!is_class<int>);
+
+    static_assert(is_function<int(int)>);
+    static_assert(!is_function<int>);
+
+    static_assert(is_ref<int&>);
+    static_assert(!is_ref<int>);
+
+    static_assert(is_arithmetic<int>);
+    static_assert(!is_arithmetic<void*>);
+
+    static_assert(is_fundamental<int>);
+    static_assert(!is_fundamental<Empty>);
+
+    static_assert(is_object<int>);
+    static_assert(!is_object<void>);
+
+    static_assert(is_scalar<int*>);
+    static_assert(!is_scalar<Empty>);
+
+    static_assert(is_compound<int*>);
+    static_assert(!is_compound<int>);
+
+    static_assert(is_member_ptr<int MemberHolder::*>);
+    static_assert(!is_member_ptr<int*>);
+
+    static_assert(is_scoped_enum<ScopedEnum>);
+    static_assert(!is_scoped_enum<PlainEnum>);
+
+    static_assert(is_const<const int>);
+    static_assert(!is_const<int>);
+
+    static_assert(is_volatile<volatile int>);
+    static_assert(!is_volatile<int>);
+
+    static_assert(is_trivially_copyable<int>);
+    static_assert(!is_trivially_copyable<std::string>);
+
+    static_assert(is_standard_layout<LayoutA>);
+    static_assert(!is_standard_layout<Poly>);
+
+    static_assert(is_empty<Empty>);
+    static_assert(!is_empty<NonEmpty>);
+
+    static_assert(is_polymorphic<Poly>);
+    static_assert(!is_polymorphic<Empty>);
+
+    static_assert(is_abstract<IAbstract>);
+    static_assert(!is_abstract<Empty>);
+
+    static_assert(is_final<Final>);
+    static_assert(!is_final<Empty>);
+
+    static_assert(is_aggregate<Aggregate>);
+    static_assert(!is_aggregate<NonAggregate>);
+
+    static_assert(is_implicit_lifetime<ImplicitLifetime>);
+    static_assert(!is_implicit_lifetime<NonImplicitLifetime>);
+
+    static_assert(is_signed<int>);
+    static_assert(!is_signed<unsigned int>);
+
+    static_assert(is_unsigned<unsigned int>);
+    static_assert(!is_unsigned<int>);
+
+    static_assert(is_bounded_array<int[3]>);
+    static_assert(!is_bounded_array<int[]>);
+
+    static_assert(is_unbounded_array<int[]>);
+    static_assert(!is_unbounded_array<int[3]>);
+
+    static_assert(is_constructible<std::string, const char*>);
+    static_assert(!is_constructible<MoveOnly, const MoveOnly&>);
+
+    static_assert(is_default_constructible<int>);
+    static_assert(!is_default_constructible<NoDefault>);
+
+    static_assert(is_copy_constructible<Copyable>);
+    static_assert(!is_copy_constructible<MoveOnly>);
+
+    static_assert(is_move_constructible<MoveOnly>);
+    static_assert(!is_move_constructible<NonMovable>);
+
+    static_assert(is_assignable<int&, int>);
+    static_assert(!is_assignable<const int&, int>);
+
+    static_assert(is_copy_assignable<Copyable>);
+    static_assert(!is_copy_assignable<NoAssign>);
+
+    static_assert(is_move_assignable<MoveOnly>);
+    static_assert(!is_move_assignable<NoMoveAssign>);
+
+    static_assert(is_destructible<int>);
+    static_assert(!is_destructible<NoDtor>);
+
+    static_assert(is_trivially_constructible<int>);
+    static_assert(!is_trivially_constructible<NonTrivial>);
+
+    static_assert(is_trivially_default_constructible<int>);
+    static_assert(!is_trivially_default_constructible<NonTrivial>);
+
+    static_assert(is_trivially_copy_constructible<int>);
+    static_assert(!is_trivially_copy_constructible<NonTrivialCopy>);
+
+    static_assert(is_trivially_move_constructible<int>);
+    static_assert(!is_trivially_move_constructible<NonTrivialMove>);
+
+    static_assert(is_trivially_assignable<int&, int>);
+    static_assert(!is_trivially_assignable<const int&, int>);
+
+    static_assert(is_trivially_copy_assignable<int>);
+    static_assert(!is_trivially_copy_assignable<NonTrivialCopyAssign>);
+
+    static_assert(is_trivially_move_assignable<int>);
+    static_assert(!is_trivially_move_assignable<NonTrivialMoveAssign>);
+
+    static_assert(is_trivially_destructible<int>);
+    static_assert(!is_trivially_destructible<NonTrivialDtor>);
+
+    static_assert(is_nothrow_constructible<int, int>);
+    static_assert(!is_nothrow_constructible<ThrowMove, ThrowMove&&>);
+
+    static_assert(is_nothrow_default_constructible<int>);
+    static_assert(!is_nothrow_default_constructible<ThrowDefault>);
+
+    static_assert(is_nothrow_copy_constructible<int>);
+    static_assert(!is_nothrow_copy_constructible<ThrowCopy>);
+
+    static_assert(is_nothrow_move_constructible<NoThrowMove>);
+    static_assert(!is_nothrow_move_constructible<ThrowMove>);
+
+    static_assert(is_nothrow_assignable<int&, int>);
+    static_assert(!is_nothrow_assignable<ThrowMove&, ThrowMove&&>);
+
+    static_assert(is_nothrow_copy_assignable<int>);
+    static_assert(!is_nothrow_copy_assignable<ThrowCopyAssign>);
+
+    static_assert(is_nothrow_move_assignable<NoThrowMove>);
+    static_assert(!is_nothrow_move_assignable<ThrowMove>);
+
+    static_assert(is_nothrow_destructible<int>);
+    static_assert(!is_nothrow_destructible<ThrowDtor>);
+
+    static_assert(has_virtual_destructor<HasVirtualDtor>);
+    static_assert(!has_virtual_destructor<NoVirtualDtor>);
+
+    static_assert(is_swappable_with<int&, int&>);
+    static_assert(!is_swappable_with<NoSwap&, NoSwap&>);
+
+    static_assert(is_swappable<int>);
+    static_assert(!is_swappable<NoSwap>);
+
+    static_assert(is_nothrow_swappable_with<NoThrowSwap&, NoThrowSwap&>);
+    static_assert(!is_nothrow_swappable_with<ThrowSwap&, ThrowSwap&>);
+
+    static_assert(is_nothrow_swappable<NoThrowSwap>);
+    static_assert(!is_nothrow_swappable<ThrowSwap>);
+
+    static_assert(has_unique_object_representations<unsigned char>);
+    static_assert(!has_unique_object_representations<Padded>);
+
+    static_assert(is_same<int, int>);
+    static_assert(!is_same<int, float>);
+
+    static_assert(is_base_of<PBase, PDerived>);
+    static_assert(!is_base_of<PDerived, PBase>);
+
+    static_assert(is_convertible<int, double>);
+    static_assert(!is_convertible<int, ExplicitFromInt>);
+
+    static_assert(is_nothrow_convertible<int, double>);
+    static_assert(!is_nothrow_convertible<ThrowConvert, int>);
+
+    static_assert(ref_constructs_from_tmp<const int&, int>);
+    static_assert(!ref_constructs_from_tmp<int&, int>);
+
+    static_assert(ref_converts_from_tmp<const int&, int>);
+    static_assert(!ref_converts_from_tmp<int&, int>);
+
+    static_assert(is_invocable<decltype(free_func), int>);
+    static_assert(!is_invocable<decltype(free_func), std::string>);
+
+    static_assert(is_invocable_result_convertible<double, decltype(free_func), int>);
+    static_assert(!is_invocable_result_convertible<std::string, decltype(free_func), int>);
+
+    static_assert(is_nothrow_invocable<Functor, int>);
+    static_assert(!is_nothrow_invocable<ThrowFunctor, int>);
+
+    static_assert(is_nothrow_invocable_result_convertible<double, Functor, int>);
+    static_assert(!is_nothrow_invocable_result_convertible<double, ThrowFunctor, int>);
+
+    assert(true);
+    return 0;
+}


### PR DESCRIPTION
## 概要
- stdのtype_traitsの型判定をコンセプトとしてラップ
  - conceptsヘッダのコンセプトはtype_traitsを完全に再現していないので、呼び出しを統一するためにも

## 変更内容
- type_traitsをラップしたコンセプトを追加

## テスト
- `tests/types/concepts.cpp`